### PR TITLE
Updated Java Install logic And updated Paper api

### DIFF
--- a/JavaInstallScripts/FabricInstall
+++ b/JavaInstallScripts/FabricInstall
@@ -1,30 +1,36 @@
-echo -e '\n> Enter Minecraft version (leave blank for latest stable version): '
+#!/bin/bash
+sudo apt update -qq  
+sudo apt install -y -qq curl jq unzip dos2unix wget
+
+cd ..
+mkdir -p server
+cd server
+
+echo -e 'Please check if your mc version is available: https://meta.fabricmc.net/v2/versions/game'
+echo -e '\n> Enter Minecraft version: '
 read MC_VERSION
 
-# Determine the Minecraft version to use
 if [ -z "$MC_VERSION" ]; then
-  MC_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/game | jq -r '.[] | select(.stable == true) | .version' | head -n1)
-  echo -e "No version entered. Using latest stable version: $MC_VERSION"
-else
-  echo -e "Using specified Minecraft version: $MC_VERSION"
+  $MC_VERSION=latest
+  echo -e 'continuing with the latest version'
 fi
 
-# Determine the latest Fabric installer version
-FABRIC_INSTALLER_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/installer | jq -r '.[0].version')
+# -- EDIT HERE | DO NOT EDIT ABOVE -- #
+SERVER_JARFILE=server.jar # LEAVE THIS PART ALONE
+FABRIC_VERSION=latest # FABRIC_VERSION: https://meta.fabricmc.net/v2/versions/installer
+# -- EDIT HERE | DO NOT EDIT BELOW -- #
 
-# Download the Fabric installer
-wget -O fabric-installer.jar "https://maven.fabricmc.net/net/fabricmc/fabric-installer/$FABRIC_INSTALLER_VERSION/fabric-installer-$FABRIC_INSTALLER_VERSION.jar"
 
-# Run the Fabric installer to set up the server
-java -jar fabric-installer.jar server -mcversion "$MC_VERSION" -downloadMinecraft
+# Enable snapshots
+if [ -z "$MC_VERSION" ] || [ "$MC_VERSION" == "latest" ]; then
+  MC_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/game | jq -r '.[] | select(.stable== true )|.version' | head -n1)
+elif [ "$MC_VERSION" == "snapshot" ]; then
+  MC_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/game | jq -r '.[] | select(.stable== false )|.version' | head -n1)
+fi
 
-# Automatically accept the Minecraft EULA
-echo "eula=true" > eula.txt
-
-# Create a script to start the server
-echo -e "#!/bin/bash\njava -Xmx2G -Xms1G -jar fabric-server-launch.jar nogui" > start.sh
-chmod +x start.sh
-
-# Confirm completion
-echo -e "Fabric server installation complete for Minecraft version $MC_VERSION"
-echo -e "To start the server, run ./start.sh in the ~/minecraft-server directory."
+if [ -z "$FABRIC_VERSION" ] || [ "$FABRIC_VERSION" == "latest" ]; then
+  FABRIC_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/installer | jq -r '.[0].version')
+fi
+wget -O fabric-installer.jar https://maven.fabricmc.net/net/fabricmc/fabric-installer/$FABRIC_VERSION/fabric-installer-$FABRIC_VERSION.jar
+java -jar fabric-installer.jar server -mcversion $MC_VERSION -downloadMinecraft
+echo -e "Install Complete"

--- a/JavaInstallScripts/FabricInstall
+++ b/JavaInstallScripts/FabricInstall
@@ -1,36 +1,35 @@
 #!/bin/bash
-sudo apt update -qq  
+set -e
+
+sudo apt update -qq
 sudo apt install -y -qq curl jq unzip dos2unix wget
 
 cd ..
 mkdir -p server
 cd server
 
-echo -e 'Please check if your mc version is available: https://meta.fabricmc.net/v2/versions/game'
-echo -e '\n> Enter Minecraft version: '
-read MC_VERSION
+MC_VERSION="${MC_VERSION:-latest}"
+echo "> Using Minecraft version: $MC_VERSION"
 
-if [ -z "$MC_VERSION" ]; then
-  $MC_VERSION=latest
-  echo -e 'continuing with the latest version'
+SERVER_JARFILE=server.jar
+FABRIC_VERSION=latest
+
+if [ "$MC_VERSION" = "latest" ]; then
+  MC_VERSION=$(curl -s https://meta.fabricmc.net/v2/versions/game \
+    | jq -r '.[] | select(.stable==true) | .version' | head -n1)
+elif [ "$MC_VERSION" = "snapshot" ]; then
+  MC_VERSION=$(curl -s https://meta.fabricmc.net/v2/versions/game \
+    | jq -r '.[] | select(.stable==false) | .version' | head -n1)
 fi
 
-# -- EDIT HERE | DO NOT EDIT ABOVE -- #
-SERVER_JARFILE=server.jar # LEAVE THIS PART ALONE
-FABRIC_VERSION=latest # FABRIC_VERSION: https://meta.fabricmc.net/v2/versions/installer
-# -- EDIT HERE | DO NOT EDIT BELOW -- #
+[ "$FABRIC_VERSION" = "latest" ] && \
+  FABRIC_VERSION=$(curl -s https://meta.fabricmc.net/v2/versions/installer | jq -r '.[0].version')
 
+wget -q -O fabric-installer.jar \
+  https://maven.fabricmc.net/net/fabricmc/fabric-installer/$FABRIC_VERSION/fabric-installer-$FABRIC_VERSION.jar
 
-# Enable snapshots
-if [ -z "$MC_VERSION" ] || [ "$MC_VERSION" == "latest" ]; then
-  MC_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/game | jq -r '.[] | select(.stable== true )|.version' | head -n1)
-elif [ "$MC_VERSION" == "snapshot" ]; then
-  MC_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/game | jq -r '.[] | select(.stable== false )|.version' | head -n1)
-fi
+java -jar fabric-installer.jar server \
+  -mcversion "$MC_VERSION" \
+  -downloadMinecraft
 
-if [ -z "$FABRIC_VERSION" ] || [ "$FABRIC_VERSION" == "latest" ]; then
-  FABRIC_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/installer | jq -r '.[0].version')
-fi
-wget -O fabric-installer.jar https://maven.fabricmc.net/net/fabricmc/fabric-installer/$FABRIC_VERSION/fabric-installer-$FABRIC_VERSION.jar
-java -jar fabric-installer.jar server -mcversion $MC_VERSION -downloadMinecraft
-echo -e "Install Complete"
+echo "> Fabric install complete"

--- a/JavaInstallScripts/FabricInstall
+++ b/JavaInstallScripts/FabricInstall
@@ -1,36 +1,30 @@
-#!/bin/bash
-sudo apt update -qq  
-sudo apt install -y -qq curl jq unzip dos2unix wget
-
-cd ..
-mkdir -p server
-cd server
-
-echo -e 'Please check if your mc version is available: https://meta.fabricmc.net/v2/versions/game'
-echo -e '\n> Enter Minecraft version: '
+echo -e '\n> Enter Minecraft version (leave blank for latest stable version): '
 read MC_VERSION
 
+# Determine the Minecraft version to use
 if [ -z "$MC_VERSION" ]; then
-  $MC_VERSION=latest
-  echo -e 'continuing with the latest version'
+  MC_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/game | jq -r '.[] | select(.stable == true) | .version' | head -n1)
+  echo -e "No version entered. Using latest stable version: $MC_VERSION"
+else
+  echo -e "Using specified Minecraft version: $MC_VERSION"
 fi
 
-# -- EDIT HERE | DO NOT EDIT ABOVE -- #
-SERVER_JARFILE=server.jar # LEAVE THIS PART ALONE
-FABRIC_VERSION=latest # FABRIC_VERSION: https://meta.fabricmc.net/v2/versions/installer
-# -- EDIT HERE | DO NOT EDIT BELOW -- #
+# Determine the latest Fabric installer version
+FABRIC_INSTALLER_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/installer | jq -r '.[0].version')
 
+# Download the Fabric installer
+wget -O fabric-installer.jar "https://maven.fabricmc.net/net/fabricmc/fabric-installer/$FABRIC_INSTALLER_VERSION/fabric-installer-$FABRIC_INSTALLER_VERSION.jar"
 
-# Enable snapshots
-if [ -z "$MC_VERSION" ] || [ "$MC_VERSION" == "latest" ]; then
-  MC_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/game | jq -r '.[] | select(.stable== true )|.version' | head -n1)
-elif [ "$MC_VERSION" == "snapshot" ]; then
-  MC_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/game | jq -r '.[] | select(.stable== false )|.version' | head -n1)
-fi
+# Run the Fabric installer to set up the server
+java -jar fabric-installer.jar server -mcversion "$MC_VERSION" -downloadMinecraft
 
-if [ -z "$FABRIC_VERSION" ] || [ "$FABRIC_VERSION" == "latest" ]; then
-  FABRIC_VERSION=$(curl -sSL https://meta.fabricmc.net/v2/versions/installer | jq -r '.[0].version')
-fi
-wget -O fabric-installer.jar https://maven.fabricmc.net/net/fabricmc/fabric-installer/$FABRIC_VERSION/fabric-installer-$FABRIC_VERSION.jar
-java -jar fabric-installer.jar server -mcversion $MC_VERSION -downloadMinecraft
-echo -e "Install Complete"
+# Automatically accept the Minecraft EULA
+echo "eula=true" > eula.txt
+
+# Create a script to start the server
+echo -e "#!/bin/bash\njava -Xmx2G -Xms1G -jar fabric-server-launch.jar nogui" > start.sh
+chmod +x start.sh
+
+# Confirm completion
+echo -e "Fabric server installation complete for Minecraft version $MC_VERSION"
+echo -e "To start the server, run ./start.sh in the ~/minecraft-server directory."

--- a/JavaInstallScripts/ForgeInstall
+++ b/JavaInstallScripts/ForgeInstall
@@ -4,140 +4,141 @@ sudo apt update -qq
 sudo apt install -y -qq jq curl
 
 export MAIN_DIR=$(pwd)
-echo -e 'fetching forge versions data...'
-JSON_DATA=`curl -sSL https://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json`
+echo -e '> fetching forge versions data...'
+
+JSON_DATA=$(curl -sSL https://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json)
 FILE_SITE=https://maven.minecraftforge.net/net/minecraftforge/forge/
-echo $MAIN_DIR
 
 cd ..
-rm ./startJavaServer
-wget https://raw.githubusercontent.com/lordofwizard/mcserver/main/startJavaServer
+rm -f ./startJavaServer
+wget -q https://raw.githubusercontent.com/lordofwizard/mcserver/main/startJavaServer
 chmod +x ./startJavaServer
+
 mkdir -p server
 cd server
 
-echo -e '\nPlease visit https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json to check for available versions and choose accordingly'
-# MC_VERSION : BUILD_TYPE: https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json
-echo -e "\n> Enter Forge build type(default 1):"
-echo -e "Type [1] recommended"
-echo -e "Type [2] latest"
+echo -e '\n> Visit https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json for available versions'
+
+# -----------------------------
+# Forge build type selection
+# -----------------------------
+echo -e "\n> Enter Forge build type (default 1):"
+echo -e "  [1] recommended"
+echo -e "  [2] latest"
 read BUILD_TYPE
 
-# if no build type, use recommended
 [[ -z $BUILD_TYPE ]] && BUILD_TYPE=1
 
 if [[ $BUILD_TYPE -eq 1 ]]; then
-	BUILD_TYPE=recommended
-
+    BUILD_TYPE=recommended
 elif [[ $BUILD_TYPE -eq 2 ]]; then
-	BUILD_TYPE=latest
-
+    BUILD_TYPE=latest
 else
-	echo -e "Please enter the appropriate number"
-	cd "$MAIN_DIR"
-	./ForgeInstall
-	exit
+    echo -e "> Invalid option"
+    cd "$MAIN_DIR"
+    ./ForgeInstall
+    exit 1
 fi
 
-echo -e "you chose $BUILD_TYPE"
+echo -e "> Build type selected: $BUILD_TYPE"
 
-echo -e "\n> Enter minecraft version: "
-read MC_VERSION
+# -----------------------------
+# Minecraft version (FROM ENV)
+# -----------------------------
+MC_VERSION="${MC_VERSION:-latest}"
+echo -e "\n> Using Minecraft version: $MC_VERSION"
 
-if [ -z $MC_VERSION ] || [ "$MC_VERSION" == "latest" ]; then
-	MC_VERSION=`echo -e ${JSON_DATA} | jq -r '.promos | to_entries[] | .key | select(contains("latest")) | split("-")[0]' | sort -t. -k2,2n -k3,3n -k4,4n | tail -1`
+if [ "$MC_VERSION" == "latest" ]; then
+    MC_VERSION=$(echo "${JSON_DATA}" | jq -r '.promos | to_entries[] | .key | select(contains("latest")) | split("-")[0]' \
+        | sort -t. -k2,2n -k3,3n -k4,4n | tail -1)
 fi
 
-if [ ! -z $FORGE_VERSION ]; then
-	DOWNLOAD_LINK=https://maven.minecraftforge.net/net/minecraftforge/forge/${FORGE_VERSION}-${BUILD_TYPE}/forge-${FORGE_VERSION}
-    	FORGE_JAR=forge-${FORGE_VERSION}*.jar
-
+# -----------------------------
+# Forge version resolution
+# -----------------------------
+if [ -n "$FORGE_VERSION" ]; then
+    DOWNLOAD_LINK=https://maven.minecraftforge.net/net/minecraftforge/forge/${FORGE_VERSION}-${BUILD_TYPE}/forge-${FORGE_VERSION}
 else
+    echo -e "\n> Minecraft version: ${MC_VERSION}"
+    echo -e "> Build type: ${BUILD_TYPE}\n"
 
-	echo -e "\nMinecraft version: ${MC_VERSION}"
-	echo -e "Build Type: ${BUILD_TYPE}\n"
+    VERSION_KEY=$(echo "${JSON_DATA}" | jq -r \
+        --arg MC_VERSION "$MC_VERSION" \
+        --arg BUILD_TYPE "$BUILD_TYPE" \
+        '.promos | to_entries[] | .key | select(contains($MC_VERSION)) | select(contains($BUILD_TYPE))' | head -1)
 
-	## some variables for getting versions and things
-	VERSION_KEY=`echo -e ${JSON_DATA} | jq -r --arg MC_VERSION "${MC_VERSION}" --arg BUILD_TYPE "${BUILD_TYPE}" '.promos | to_entries[] | .key | select(contains($BUILD_TYPE)) | select(contains($MC_VERSION))' | head -1`
-	echo $VERSION_KEY
-
-	## locating the forge version
-    if [ "${VERSION_KEY}" == "" ] && [ "${BUILD_TYPE}" == "latest" ]; then
-        echo -e "dropping back to latest from recommended due to there not being a recommended version of forge for the mc version requested."
-        VERSION_KEY=`echo -e ${JSON_DATA} | jq -r --arg MC_VERSION "${MC_VERSION}" '.promos | to_entries[] | .key | select(contains($MC_VERSION)) | select(contains("latest"))' | head -1`
+    if [[ -z "$VERSION_KEY" && "$BUILD_TYPE" == "latest" ]]; then
+        echo -e "> No recommended build found, falling back to latest"
+        VERSION_KEY=$(echo "${JSON_DATA}" | jq -r \
+            --arg MC_VERSION "$MC_VERSION" \
+            '.promos | to_entries[] | .key | select(contains($MC_VERSION)) | select(contains("latest"))' | head -1)
     fi
 
-	## Error if the mc version set wasn't valid.
-    if [ "${VERSION_KEY}" == "" ] || [ "${VERSION_KEY}" == "null" ]; then
-    	echo -e "The install failed because there is no valid version of forge for the version on minecraft selected."
-    	exit 1
+    if [[ -z "$VERSION_KEY" || "$VERSION_KEY" == "null" ]]; then
+        echo -e "> No valid Forge version found for Minecraft $MC_VERSION"
+        exit 1
     fi
 
-	FORGE_VERSION=`echo -e ${JSON_DATA} | jq -r --arg VERSION_KEY "$VERSION_KEY" '.promos | .[$VERSION_KEY]'`
+    FORGE_VERSION=$(echo "${JSON_DATA}" | jq -r --arg KEY "$VERSION_KEY" '.promos[$KEY]')
 
-	if [ "${MC_VERSION}" == "1.7.10" ] || [ "${MC_VERSION}" == "1.8.9" ]; then
+    if [[ "$MC_VERSION" == "1.7.10" || "$MC_VERSION" == "1.8.9" ]]; then
         DOWNLOAD_LINK=${FILE_SITE}${MC_VERSION}-${FORGE_VERSION}-${MC_VERSION}/forge-${MC_VERSION}-${FORGE_VERSION}-${MC_VERSION}
-    
-	else
+    else
         DOWNLOAD_LINK=${FILE_SITE}${MC_VERSION}-${FORGE_VERSION}/forge-${MC_VERSION}-${FORGE_VERSION}
-	
-	fi
+    fi
 fi
 
-echo -e "Downloading forge version ${FORGE_VERSION}"
-echo -e "Download link is ${DOWNLOAD_LINK}"
-if [ ! -z "${DOWNLOAD_LINK}" ]; then 
-    if curl --output /dev/null --silent --head --fail ${DOWNLOAD_LINK}-installer.jar; then
-        echo -e "installer jar download link is valid."
-    else
-        echo -e "link is invalid closing out"
-        exit 2
-    fi
-else
-    echo -e "no download link closing out"
+# -----------------------------
+# Download + install
+# -----------------------------
+echo -e "\n> Downloading Forge $FORGE_VERSION"
+echo -e "> URL: ${DOWNLOAD_LINK}-installer.jar"
+
+if ! curl --silent --head --fail "${DOWNLOAD_LINK}-installer.jar"; then
+    echo -e "> Invalid Forge download link"
+    exit 2
+fi
+
+curl -sSL -o installer.jar "${DOWNLOAD_LINK}-installer.jar"
+
+if [ ! -f installer.jar ]; then
+    echo -e "> Forge installer download failed"
     exit 3
 fi
 
-curl -s -o installer.jar -sS ${DOWNLOAD_LINK}-installer.jar
+echo -e "\n> Installing Forge server"
+java -jar installer.jar --installServer || { echo -e "> Forge install failed"; exit 4; }
 
-#Checking if downloaded jars exist
-if [ ! -f ./installer.jar ]; then
-    echo "!!! Error by downloading forge version ${FORGE_VERSION} !!!"
-    exit
-fi
+rm -f installer.jar
 
-#Installing server
-echo -e "Installing forge server.\n"
-java -jar installer.jar --installServer || { echo -e "install failed"; exit 4; }
+# -----------------------------
+# Server launch files
+# -----------------------------
+cd "$MAIN_DIR/../server"
+echo "eula=true" > eula.txt
 
-#Deleting installer.jar
-echo -e "Deleting installer.jar file.\n"
-rm -rf installer.jar
-
-# creating launch file
-cd $MAIN_DIR/../server
-echo "eula=true" > eula.txt     # accepted the eula
 FORGE_RUN_FILE=./run.sh
+
 if [ -f "$FORGE_RUN_FILE" ]; then
-    echo "#!/bin/bash
+    cat > run.sh <<EOF
+#!/bin/bash
 export JAVA=../bin/java_bins/bin/java
+\$JAVA @user_jvm_args.txt @libraries/net/minecraftforge/forge/${MC_VERSION}-${FORGE_VERSION}/unix_args.txt "\$@"
+EOF
+    chmod +x run.sh
 
-\$JAVA @user_jvm_args.txt @libraries/net/minecraftforge/forge/${MC_VERSION}-${FORGE_VERSION}/unix_args.txt \"\$@\"" > run.sh
-    chmod +x ./run.sh
-
-    echo '#!/bin/bash
+    cat > ../startJavaServer <<EOF
+#!/bin/bash
 cd server
-./run.sh -nogui' > ../startJavaServer
+./run.sh -nogui
+EOF
     chmod +x ../startJavaServer
-
 else
-    # 1.7.10 thanks to Optifinel3ss#9059
-    if [ "$MC_VERSION" == "1.8.9" ] || [ "$MC_VERSION" == "1.7.10" ]; then
+    if [[ "$MC_VERSION" == "1.7.10" || "$MC_VERSION" == "1.8.9" ]]; then
         FORGE_JAR=forge-${MC_VERSION}-${FORGE_VERSION}-${MC_VERSION}-universal.jar
     else
         FORGE_JAR=forge-${MC_VERSION}-${FORGE_VERSION}.jar
     fi
-    SERVER_JARFILE=server.jar
-    mv $FORGE_JAR $SERVER_JARFILE
 
+    mv "$FORGE_JAR" server.jar
 fi

--- a/JavaInstallScripts/PaperInstall
+++ b/JavaInstallScripts/PaperInstall
@@ -1,5 +1,4 @@
 #!/bin/bash
-#!/bin/bash
 # Paper Installation Script
 #
 # Server Files: /mnt/server
@@ -10,64 +9,47 @@ cd ..
 mkdir -p server
 cd server
 
-
-echo -e "\n> Enter minecraft version for server: "
+echo -e "\n> Enter Minecraft version for server: "
 MINECRAFT_VERSION=latest
 read MINECRAFT_VERSION
 
-
 # -- EDIT HERE | DO NOT EDIT ABOVE -- #
-BUILD_NUMBER=latest # https://papermc.io/downloads
-PROJECT=paper # PROJECT: https://papermc.io/api/v2/projects/
+BUILD_NUMBER=latest # https://api.papermc.io/v2/projects/paper
+PROJECT=paper # PROJECT: https://api.papermc.io/v2/projects/
 SERVER_JARFILE=server.jar # LEAVE THIS PART ALONE
-# -- EDIT HERE | DO NOT EDIT BELOW -- # 
-
-
-
+# -- EDIT HERE | DO NOT EDIT BELOW -- #
 
 if [ -n "${DL_PATH}" ]; then
-	echo -e "Using supplied download url: ${DL_PATH}"
-	DOWNLOAD_URL=`eval echo $(echo ${DL_PATH} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+    echo -e "Using supplied download URL: ${DL_PATH}"
+    DOWNLOAD_URL=`eval echo $(echo ${DL_PATH} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
 else
-	VER_EXISTS=`curl -s https://papermc.io/api/v2/projects/${PROJECT} | jq -r --arg VERSION $MINECRAFT_VERSION '.versions[] | contains($VERSION)' | grep true`
-	LATEST_VERSION=`curl -s https://papermc.io/api/v2/projects/${PROJECT} | jq -r '.versions' | jq -r '.[-1]'`
-
-	if [ "${VER_EXISTS}" == "true" ]; then
-		echo -e "Version is valid. Using version ${MINECRAFT_VERSION}"
-	else
-		echo -e "Using the latest ${PROJECT} version"
-		MINECRAFT_VERSION=${LATEST_VERSION}
-	fi
-	
-	BUILD_EXISTS=`curl -s https://papermc.io/api/v2/projects/${PROJECT}/versions/${MINECRAFT_VERSION} | jq -r --arg BUILD ${BUILD_NUMBER} '.builds[] | tostring | contains($BUILD)' | grep true`
-	LATEST_BUILD=`curl -s https://papermc.io/api/v2/projects/${PROJECT}/versions/${MINECRAFT_VERSION} | jq -r '.builds' | jq -r '.[-1]'`
-	
-	if [ "${BUILD_EXISTS}" == "true" ]; then
-		echo -e "Build is valid for version ${MINECRAFT_VERSION}. Using build ${BUILD_NUMBER}"
-	else
-		echo -e "Using the latest ${PROJECT} build for version ${MINECRAFT_VERSION}"
-		BUILD_NUMBER=${LATEST_BUILD}
-	fi
-	
-	JAR_NAME=${PROJECT}-${MINECRAFT_VERSION}-${BUILD_NUMBER}.jar
-	
-	echo "Version being downloaded"
-	echo -e "MC Version: ${MINECRAFT_VERSION}"
-	echo -e "Build: ${BUILD_NUMBER}"
-	echo -e "JAR Name of Build: ${JAR_NAME}"
-	DOWNLOAD_URL=https://papermc.io/api/v2/projects/${PROJECT}/versions/${MINECRAFT_VERSION}/builds/${BUILD_NUMBER}/downloads/${JAR_NAME}
+    LATEST_VERSION=$(curl -s "https://api.papermc.io/v2/projects/${PROJECT}" | jq -r '.versions[-1]')
+    if [ "$MINECRAFT_VERSION" == "latest" ]; then
+        MINECRAFT_VERSION=${LATEST_VERSION}
+        echo -e "Using latest available version: ${MINECRAFT_VERSION}"
+    fi
+    
+    LATEST_BUILD=$(curl -s "https://api.papermc.io/v2/projects/${PROJECT}/versions/${MINECRAFT_VERSION}/builds" | jq -r '.builds | map(select(.channel == "default") | .build) | .[-1]')
+    
+    if [ "$BUILD_NUMBER" == "latest" ]; then
+        BUILD_NUMBER=${LATEST_BUILD}
+        echo -e "Using latest stable build: ${BUILD_NUMBER}"
+    fi
+    
+    JAR_NAME=${PROJECT}-${MINECRAFT_VERSION}-${BUILD_NUMBER}.jar
+    DOWNLOAD_URL="https://api.papermc.io/v2/projects/${PROJECT}/versions/${MINECRAFT_VERSION}/builds/${BUILD_NUMBER}/downloads/${JAR_NAME}"
 fi
 
 SERVER_JARFILE=server.jar
-echo -e "Running curl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}"
+echo -e "Downloading ${SERVER_JARFILE} from ${DOWNLOAD_URL}"
 
 if [ -f ${SERVER_JARFILE} ]; then
-	mv ${SERVER_JARFILE} ${SERVER_JARFILE}.old
+    mv ${SERVER_JARFILE} ${SERVER_JARFILE}.old
 fi
 
 curl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}
 
 if [ ! -f server.properties ]; then
-    echo -e "Downloading MC server.properties"
+    echo -e "Downloading Minecraft server.properties"
     curl -o server.properties https://raw.githubusercontent.com/parkervcp/eggs/master/minecraft/java/server.properties
 fi

--- a/JavaInstallScripts/PaperInstall
+++ b/JavaInstallScripts/PaperInstall
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Paper Installation Script
-#
-# Server Files: /mnt/server
+
+set -e
+
 sudo apt update -qq
 sudo apt install -y -qq curl jq > /dev/null
 
@@ -9,47 +10,45 @@ cd ..
 mkdir -p server
 cd server
 
-echo -e "\n> Enter Minecraft version for server: "
-MINECRAFT_VERSION=latest
-read MINECRAFT_VERSION
+# -----------------------------
+# Minecraft version (from installJava)
+# -----------------------------
+MINECRAFT_VERSION="${MC_VERSION:-latest}"
+echo "> Using Minecraft version: $MINECRAFT_VERSION"
 
-# -- EDIT HERE | DO NOT EDIT ABOVE -- #
-BUILD_NUMBER=latest # https://api.papermc.io/v2/projects/paper
-PROJECT=paper # PROJECT: https://api.papermc.io/v2/projects/
-SERVER_JARFILE=server.jar # LEAVE THIS PART ALONE
-# -- EDIT HERE | DO NOT EDIT BELOW -- #
+# -- CONFIG --
+BUILD_NUMBER=latest
+PROJECT=paper
+SERVER_JARFILE=server.jar
+# ------------
 
 if [ -n "${DL_PATH}" ]; then
-    echo -e "Using supplied download URL: ${DL_PATH}"
-    DOWNLOAD_URL=`eval echo $(echo ${DL_PATH} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+    DOWNLOAD_URL=$(eval echo "${DL_PATH}")
 else
     LATEST_VERSION=$(curl -s "https://api.papermc.io/v2/projects/${PROJECT}" | jq -r '.versions[-1]')
-    if [ "$MINECRAFT_VERSION" == "latest" ]; then
-        MINECRAFT_VERSION=${LATEST_VERSION}
-        echo -e "Using latest available version: ${MINECRAFT_VERSION}"
+
+    if [ "$MINECRAFT_VERSION" = "latest" ]; then
+        MINECRAFT_VERSION="$LATEST_VERSION"
+        echo "> Resolved latest version: $MINECRAFT_VERSION"
     fi
-    
-    LATEST_BUILD=$(curl -s "https://api.papermc.io/v2/projects/${PROJECT}/versions/${MINECRAFT_VERSION}/builds" | jq -r '.builds | map(select(.channel == "default") | .build) | .[-1]')
-    
-    if [ "$BUILD_NUMBER" == "latest" ]; then
-        BUILD_NUMBER=${LATEST_BUILD}
-        echo -e "Using latest stable build: ${BUILD_NUMBER}"
-    fi
-    
-    JAR_NAME=${PROJECT}-${MINECRAFT_VERSION}-${BUILD_NUMBER}.jar
+
+    LATEST_BUILD=$(curl -s \
+      "https://api.papermc.io/v2/projects/${PROJECT}/versions/${MINECRAFT_VERSION}/builds" \
+      | jq -r '.builds | map(select(.channel=="default")|.build) | .[-1]')
+
+    [ "$BUILD_NUMBER" = "latest" ] && BUILD_NUMBER="$LATEST_BUILD"
+
+    JAR_NAME="${PROJECT}-${MINECRAFT_VERSION}-${BUILD_NUMBER}.jar"
     DOWNLOAD_URL="https://api.papermc.io/v2/projects/${PROJECT}/versions/${MINECRAFT_VERSION}/builds/${BUILD_NUMBER}/downloads/${JAR_NAME}"
 fi
 
-SERVER_JARFILE=server.jar
-echo -e "Downloading ${SERVER_JARFILE} from ${DOWNLOAD_URL}"
-
-if [ -f ${SERVER_JARFILE} ]; then
-    mv ${SERVER_JARFILE} ${SERVER_JARFILE}.old
-fi
-
-curl -o ${SERVER_JARFILE} ${DOWNLOAD_URL}
+echo "> Downloading server.jar"
+[ -f server.jar ] && mv server.jar server.jar.old
+curl -sSL -o server.jar "$DOWNLOAD_URL"
 
 if [ ! -f server.properties ]; then
-    echo -e "Downloading Minecraft server.properties"
-    curl -o server.properties https://raw.githubusercontent.com/parkervcp/eggs/master/minecraft/java/server.properties
+    curl -sSL -o server.properties \
+      https://raw.githubusercontent.com/parkervcp/eggs/master/minecraft/java/server.properties
 fi
+
+echo "> Paper install complete"

--- a/JavaInstallScripts/VanillaInstall
+++ b/JavaInstallScripts/VanillaInstall
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 sudo apt update -qq
 sudo apt install -y -qq jq curl
 
@@ -6,38 +8,29 @@ cd ..
 mkdir -p server
 cd server
 
+LATEST_RELEASE=$(curl -s https://launchermeta.mojang.com/mc/game/version_manifest.json | jq -r '.latest.release')
+LATEST_SNAPSHOT=$(curl -s https://launchermeta.mojang.com/mc/game/version_manifest.json | jq -r '.latest.snapshot')
 
-# -- EDIT HERE | DO NOT EDIT ABOVE -- #
-# VANILLA_VERSION: https://launchermeta.mojang.com/mc/game/version_manifest.json
-# -- EDIT HERE | DO NOT EDIT BELOW -- # 
+VANILLA_VERSION="${MC_VERSION:-latest}"
+echo "> Using Minecraft version: $VANILLA_VERSION"
 
-
-LATEST_VERSION=`sudo curl -s https://launchermeta.mojang.com/mc/game/version_manifest.json | jq -r '.latest.release'`
-LATEST_SNAPSHOT_VERSION=`sudo -s curl https://launchermeta.mojang.com/mc/game/version_manifest.json | jq -r '.latest.snapshot'`
-
-echo -e "\nlatest version is $LATEST_VERSION"
-echo -e "latest snapshot is $LATEST_SNAPSHOT_VERSION"
-
-echo -e "\n> Enter minecraft version for server: "
-VANILLA_VERSION=latest
-read VANILLA_VERSION
-
-if [ -z "$VANILLA_VERSION" ] || [ "$VANILLA_VERSION" == "latest" ]; then
-  MANIFEST_URL=$(curl -sSL https://launchermeta.mojang.com/mc/game/version_manifest.json | jq --arg VERSION $LATEST_VERSION -r '.versions | .[] | select(.id== $VERSION )|.url')
-elif [ "$VANILLA_VERSION" == "snapshot" ]; then
-  MANIFEST_URL=$(curl -sSL https://launchermeta.mojang.com/mc/game/version_manifest.json | jq --arg VERSION $LATEST_SNAPSHOT_VERSION -r '.versions | .[] | select(.id== $VERSION )|.url')
+if [ "$VANILLA_VERSION" = "latest" ]; then
+  TARGET="$LATEST_RELEASE"
+elif [ "$VANILLA_VERSION" = "snapshot" ]; then
+  TARGET="$LATEST_SNAPSHOT"
 else
-  MANIFEST_URL=$(curl -sSL https://launchermeta.mojang.com/mc/game/version_manifest.json | jq --arg VERSION $VANILLA_VERSION -r '.versions | .[] | select(.id== $VERSION )|.url')
+  TARGET="$VANILLA_VERSION"
 fi
 
-DOWNLOAD_URL=$(curl ${MANIFEST_URL} | jq .downloads.server | jq -r '. | .url')
-if [ -z $DOWNLOAD_URL ]
-then
-  echo "Invalid version provided"
+MANIFEST_URL=$(curl -s https://launchermeta.mojang.com/mc/game/version_manifest.json \
+  | jq -r --arg V "$TARGET" '.versions[] | select(.id==$V) | .url')
+
+if [ -z "$MANIFEST_URL" ]; then
+  echo "Invalid Minecraft version"
   exit 1
 fi
 
-echo -e "running: curl -o server.jar $DOWNLOAD_URL"
-sudo curl -o server.jar $DOWNLOAD_URL
+DOWNLOAD_URL=$(curl -s "$MANIFEST_URL" | jq -r '.downloads.server.url')
 
-echo -e "Install Complete"
+curl -sSL -o server.jar "$DOWNLOAD_URL"
+echo "> Vanilla install complete"

--- a/install
+++ b/install
@@ -10,7 +10,7 @@ export MAIN_DIR="$PWD"
 echo "Which Server do you want to install?"
 echo "Type [1] Java Server"
 echo "Type [2] Bedrock Server"
-read -r choiceForServer
+read -rp "> " choiceForServer
 
 # -----------------------------
 # Server choice

--- a/install
+++ b/install
@@ -10,12 +10,9 @@ choiceForServer=1
 read choiceForServer
 
 # Installing Java 16 JDK and playit
+#chaged jdk 16 to jdk 21 for higher version support, uncomment to lower versions for support
 
-#wget -q "https://download.oracle.com/java/17/archive/jdk-17.0.3_linux-x64_bin.tar.gz" -O bin/java.tar.xz
-wget -q "https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_linux-x64_bin.tar.gz" -O bin/java.tar.xz
-cd $MAIN_DIR/bin
-echo "> Extracting Java JDK 16 to the bin/ folder. [THIS MAY TAKE SOME TIME] Replace it if you want to use older version of JAVA."
-tar -xf java.tar.xz && mv "jdk-17.0.1" java_bins
+sudo apt install openjdk-21-jdk
 
 cd $MAIN_DIR
 # If choice is 0 or null then run this command

--- a/install
+++ b/install
@@ -11,17 +11,12 @@ read choiceForServer
 
 # Installing Latest Java JDK and playit
 
-JDK_URL=$(wget -qO- "https://api.adoptium.net/v3/assets/latest/17/hotspot" | grep -oP '(?<=browser_download_url":")[^"]*linux-x64.tar.gz')
+JDK_URL="https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.deb"
 
-if [ -z "$JDK_URL" ]; then
-  echo "Failed to fetch the latest JDK URL. Exiting..."
-  exit 1
-fi
-
-wget -q "$JDK_URL" -O bin/java.tar.xz
+wget -q "$JDK_URL" -O bin/java.deb
 cd $MAIN_DIR/bin
-echo "> Extracting Java JDK to the bin/ folder. [THIS MAY TAKE SOME TIME]"
-tar -xf java.tar.xz && mv jdk-* java_bins
+echo "> Installing Java JDK 21..."
+sudo dpkg -i java.deb
 
 cd $MAIN_DIR
 # If choice is 0 or null then run this command

--- a/install
+++ b/install
@@ -1,43 +1,73 @@
 #!/bin/bash
-mkdir bin
-chmod +x *
 export MAIN_DIR=$PWD
-echo "Which Server do you want to install?"
-echo "Type [1] Java Server"
-echo "Type [2] Bedrock Server"
+echo "> Starting the server up. Please wait..."                                                                                 
+echo "> Installing Dependencies..."
 
-choiceForServer=1
-read choiceForServer
+sudo apt install -y -qq screen wget  
 
-# Installing Java 16 JDK and playit
-#chaged jdk 16 to jdk 21 for higher version support, uncomment to lower versions for support
+echo "> Dependencies Installed!"
 
-sudo apt install openjdk-21-jdk
+# Download and set up JDK 21
+mkdir -p $MAIN_DIR/bin
+wget -q "https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz" -O $MAIN_DIR/bin/java.tar.gz
+cd $MAIN_DIR/bin
+echo "> Extracting Java JDK 21 to the bin/ folder. [THIS MAY TAKE SOME TIME]"
+tar -xf java.tar.gz && mv jdk-21 java_bins
+
+# Set Java 21 as default
+export JAVA_HOME=$MAIN_DIR/bin/java_bins
+export PATH=$JAVA_HOME/bin:$PATH
 
 cd $MAIN_DIR
-# If choice is 0 or null then run this command
-if [[ -z $choiceForServer ]]; then
+echo "> Checking Server Type..."
+if [ -f $MAIN_DIR/server/bedrock_server ]; then
 
-  echo "> Invaild Respond. Please try again."
-  ./install
+echo "> Bedrock Server Detected! Starting Server up..."
 
-# If choice is 1 then run this command
-elif [[ $choiceForServer == 1 ]]; then
-	
-	echo "> Running Java Installation..."
-  ./installJava
+elif [ ! -f $MAIN_DIR/server/eula.txt ]; then
 
-# If choice is 1 then run this command
-elif [[ $choiceForServer == 2 ]]; then
-	
-	echo "> Running Bedrock Installation..."
-  ./installBedrock
+cd $MAIN_DIR/server
+echo "> EULA doesn't exist! Creating one!"
+echo "eula=true" > eula.txt
+echo "> EULA Completed! Restarting Server"
+cd $MAIN_DIR
+screen -S server -d -m ./startJavaServer
+clear
+echo "> Your server is performing a second restart to fix the EULA file."
+killall screen
+./startserver
+exit
+elif [ -f $MAIN_DIR/server/eula.txt ]; then
+echo "> EULA Detected! Starting Server up..."
 
 else
-	echo "> Invaild Respond. Please try again."
-	./install
+echo "> Your server isn't set up properly. Force uninstall..."
+cd $MAIN_DIR
+./uninstall
+echo "> Confirmed Uninstallation! Restarting Installation..."
+./install
 fi
-echo "> Installing AFK(Away From Keyboard) Script "
-python3 -m pip install bpytop
-echo ""
 
+# Prevent multiple instances of the same app from running
+killall screen
+
+screen -S server -d -m ./startJavaServer # Starting Java Server
+screen -S server -d -m ./startBedrockServer # Starting Bedrock Server
+screen -S afk -d -m ./startAfk # Starting AFK app aka bpytop.
+screen -S playit -d -m ./startPlayIt # Starting Playit
+
+cd $MAIN_DIR/server
+screen -S server -d -m ./bin/php7/bin/php ./PocketMine-MP.phar --no-wizard --disable-ansi # Starting PocketmineMP
+screen -S server -d -m java --add-opens java.base/java.nio=io.netty.common --add-exports java.base/jdk.internal.misc=io.netty.common -p modules -m gomint.server/io.gomint.server.Bootstrap # Starting GoMint
+cd $MAIN_DIR
+
+echo "-- Your Server is now ONLINE! --"
+echo
+echo "Type [screen -ls] to check the Running Processes"
+echo "Type [screen -r server] to enter the Server Console"
+echo "Type [screen -r playit] to view your Server IP"
+echo ""
+echo "> To stop your server, type './stopserver' to stop"
+
+echo -e '\nChecking if the server has launched properly'
+./.checkserver 2> crash.log

--- a/install
+++ b/install
@@ -1,73 +1,47 @@
 #!/bin/bash
+mkdir bin
+chmod +x *
 export MAIN_DIR=$PWD
-echo "> Starting the server up. Please wait..."                                                                                 
-echo "> Installing Dependencies..."
+echo "Which Server do you want to install?"
+echo "Type [1] Java Server"
+echo "Type [2] Bedrock Server"
 
-sudo apt install -y -qq screen wget  
+choiceForServer=1
+read choiceForServer
 
-echo "> Dependencies Installed!"
+# Installing Latest Java JDK and playit
 
-# Download and set up JDK 21
-mkdir -p $MAIN_DIR/bin
-wget -q "https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz" -O $MAIN_DIR/bin/java.tar.gz
-cd $MAIN_DIR/bin
-echo "> Extracting Java JDK 21 to the bin/ folder. [THIS MAY TAKE SOME TIME]"
-tar -xf java.tar.gz && mv jdk-21 java_bins
+JDK_URL=$(wget -qO- "https://api.adoptium.net/v3/assets/latest/17/hotspot" | grep -oP '(?<=browser_download_url":")[^"]*linux-x64.tar.gz')
 
-# Set Java 21 as default
-export JAVA_HOME=$MAIN_DIR/bin/java_bins
-export PATH=$JAVA_HOME/bin:$PATH
-
-cd $MAIN_DIR
-echo "> Checking Server Type..."
-if [ -f $MAIN_DIR/server/bedrock_server ]; then
-
-echo "> Bedrock Server Detected! Starting Server up..."
-
-elif [ ! -f $MAIN_DIR/server/eula.txt ]; then
-
-cd $MAIN_DIR/server
-echo "> EULA doesn't exist! Creating one!"
-echo "eula=true" > eula.txt
-echo "> EULA Completed! Restarting Server"
-cd $MAIN_DIR
-screen -S server -d -m ./startJavaServer
-clear
-echo "> Your server is performing a second restart to fix the EULA file."
-killall screen
-./startserver
-exit
-elif [ -f $MAIN_DIR/server/eula.txt ]; then
-echo "> EULA Detected! Starting Server up..."
-
-else
-echo "> Your server isn't set up properly. Force uninstall..."
-cd $MAIN_DIR
-./uninstall
-echo "> Confirmed Uninstallation! Restarting Installation..."
-./install
+if [ -z "$JDK_URL" ]; then
+  echo "Failed to fetch the latest JDK URL. Exiting..."
+  exit 1
 fi
 
-# Prevent multiple instances of the same app from running
-killall screen
+wget -q "$JDK_URL" -O bin/java.tar.xz
+cd $MAIN_DIR/bin
+echo "> Extracting Java JDK to the bin/ folder. [THIS MAY TAKE SOME TIME]"
+tar -xf java.tar.xz && mv jdk-* java_bins
 
-screen -S server -d -m ./startJavaServer # Starting Java Server
-screen -S server -d -m ./startBedrockServer # Starting Bedrock Server
-screen -S afk -d -m ./startAfk # Starting AFK app aka bpytop.
-screen -S playit -d -m ./startPlayIt # Starting Playit
-
-cd $MAIN_DIR/server
-screen -S server -d -m ./bin/php7/bin/php ./PocketMine-MP.phar --no-wizard --disable-ansi # Starting PocketmineMP
-screen -S server -d -m java --add-opens java.base/java.nio=io.netty.common --add-exports java.base/jdk.internal.misc=io.netty.common -p modules -m gomint.server/io.gomint.server.Bootstrap # Starting GoMint
 cd $MAIN_DIR
+# If choice is 0 or null then run this command
+if [[ -z $choiceForServer ]]; then
+  echo "> Invalid Response. Please try again."
+  ./install
 
-echo "-- Your Server is now ONLINE! --"
-echo
-echo "Type [screen -ls] to check the Running Processes"
-echo "Type [screen -r server] to enter the Server Console"
-echo "Type [screen -r playit] to view your Server IP"
+# If choice is 1 then run this command
+elif [[ $choiceForServer == 1 ]]; then
+  echo "> Running Java Installation..."
+  ./installJava
+
+# If choice is 2 then run this command
+elif [[ $choiceForServer == 2 ]]; then
+  echo "> Running Bedrock Installation..."
+  ./installBedrock
+else
+  echo "> Invalid Response. Please try again."
+  ./install
+fi
+echo "> Installing AFK (Away From Keyboard) Script "
+python3 -m pip install bpytop
 echo ""
-echo "> To stop your server, type './stopserver' to stop"
-
-echo -e '\nChecking if the server has launched properly'
-./.checkserver 2> crash.log

--- a/install
+++ b/install
@@ -1,42 +1,55 @@
 #!/bin/bash
-mkdir bin
+
+set -e
+
+mkdir -p bin
 chmod +x *
-export MAIN_DIR=$PWD
+
+export MAIN_DIR="$PWD"
+
 echo "Which Server do you want to install?"
 echo "Type [1] Java Server"
 echo "Type [2] Bedrock Server"
+read -r choiceForServer
 
-choiceForServer=1
-read choiceForServer
-
-# Installing Latest Java JDK and playit
-
+# -----------------------------
+# Install Oracle JDK 21
+# -----------------------------
 JDK_URL="https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.deb"
 
+echo "> Downloading Java JDK 21..."
 wget -q "$JDK_URL" -O bin/java.deb
-cd $MAIN_DIR/bin
-echo "> Installing Java JDK 21..."
-sudo dpkg -i java.deb
 
-cd $MAIN_DIR
-# If choice is 0 or null then run this command
-if [[ -z $choiceForServer ]]; then
-  echo "> Invalid Response. Please try again."
+cd "$MAIN_DIR/bin"
+echo "> Installing Java JDK 21..."
+sudo dpkg -i java.deb || sudo apt -f install -y
+
+cd "$MAIN_DIR"
+
+# -----------------------------
+# Server choice
+# -----------------------------
+if [[ -z "$choiceForServer" ]]; then
+  echo "> Invalid response"
   ./install
 
-# If choice is 1 then run this command
-elif [[ $choiceForServer == 1 ]]; then
-  echo "> Running Java Installation..."
+elif [[ "$choiceForServer" == "1" ]]; then
+  echo "> Running Java installation..."
   ./installJava
 
-# If choice is 2 then run this command
-elif [[ $choiceForServer == 2 ]]; then
-  echo "> Running Bedrock Installation..."
+elif [[ "$choiceForServer" == "2" ]]; then
+  echo "> Running Bedrock installation..."
   ./installBedrock
+
 else
-  echo "> Invalid Response. Please try again."
+  echo "> Invalid response"
   ./install
 fi
-echo "> Installing AFK (Away From Keyboard) Script "
-python3 -m pip install bpytop
-echo ""
+
+# -----------------------------
+# AFK / Monitor tool
+# -----------------------------
+echo "> Installing AFK monitor..."
+python3 -m pip install --user bpytop
+
+echo "> Install finished."

--- a/install
+++ b/install
@@ -13,20 +13,6 @@ echo "Type [2] Bedrock Server"
 read -r choiceForServer
 
 # -----------------------------
-# Install Oracle JDK 21
-# -----------------------------
-JDK_URL="https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.deb"
-
-echo "> Downloading Java JDK 21..."
-wget -q "$JDK_URL" -O bin/java.deb
-
-cd "$MAIN_DIR/bin"
-echo "> Installing Java JDK 21..."
-sudo dpkg -i java.deb || sudo apt -f install -y
-
-cd "$MAIN_DIR"
-
-# -----------------------------
 # Server choice
 # -----------------------------
 if [[ -z "$choiceForServer" ]]; then
@@ -47,7 +33,7 @@ else
 fi
 
 # -----------------------------
-# AFK / Monitor tool
+# AFK 
 # -----------------------------
 echo "> Installing AFK monitor..."
 python3 -m pip install --user bpytop

--- a/installJava
+++ b/installJava
@@ -1,14 +1,18 @@
 #!/bin/bash
-
 set -e
+
 export THIS_DIR="$PWD"
 
 # -----------------------------
-# Ask Minecraft version
+# Ask Minecraft version (ONCE)
 # -----------------------------
 echo ""
-echo "Enter Minecraft version (example: 1.14.2, 1.16.5, 1.18.2, 1.20.4):"
+echo "Enter Minecraft version (example: 1.14.2, 1.16.5, 1.18.2, 1.20.4 or latest)"
 read -rp "> " MC_VERSION
+
+# Default
+MC_VERSION="${MC_VERSION:-latest}"
+export MC_VERSION
 
 # -----------------------------
 # Decide Java version
@@ -22,27 +26,35 @@ case "$MC_VERSION" in
   1.17*)
     JAVA_PKG="temurin-16-jdk"
     ;;
-  1.18*|1.19*|1.20.[0-4])
+  1.18*|1.19*)
     JAVA_PKG="temurin-17-jdk"
     ;;
-  *)
+  1.20*)
     JAVA_PKG="temurin-21-jdk"
+    ;;
+  latest)
+    JAVA_PKG="temurin-21-jdk"
+    ;;
+  *)
+    JAVA_PKG="temurin-17-jdk"
     ;;
 esac
 
-echo "> Minecraft $MC_VERSION detected"
-echo "> Installing Java: $JAVA_PKG"
+echo "> Minecraft version: $MC_VERSION"
+echo "> Installing Java package: $JAVA_PKG"
 
 # -----------------------------
 # Dependencies (UNCHANGED)
 # -----------------------------
 sudo apt update -y
-sudo apt install -y screen neofetch curl wget apt-transport-https ca-certificates gnupg
+sudo apt install -y \
+  screen neofetch curl wget jq \
+  apt-transport-https ca-certificates gnupg lsb-release
 
 # -----------------------------
-# Adoptium repo
+# Adoptium (Temurin) repo
 # -----------------------------
-if ! grep -q adoptium /etc/apt/sources.list.d/adoptium.list 2>/dev/null; then
+if [[ ! -f /etc/apt/sources.list.d/adoptium.list ]]; then
   wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public \
     | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/adoptium.gpg
 
@@ -53,7 +65,7 @@ fi
 sudo apt update -y
 sudo apt install -y "$JAVA_PKG"
 
-echo "> Java installed:"
+echo "> Java installed successfully"
 java -version
 
 # -----------------------------
@@ -62,7 +74,7 @@ java -version
 mkdir -p server
 
 # -----------------------------
-# Server installer menu (UNCHANGED)
+# Server installer menu
 # -----------------------------
 install_server () {
   choice="$1"
@@ -80,7 +92,7 @@ install_server () {
     *)
       echo "> Invalid response"
       cd "$THIS_DIR"
-      ./installJava
+      exec ./installJava
       ;;
   esac
 }
@@ -112,7 +124,7 @@ sudo apt install -y playit
 echo "> Playit.gg installed"
 
 # -----------------------------
-# Start prompt (UNCHANGED)
+# Start prompt
 # -----------------------------
 echo ""
 echo "Start server now?"

--- a/installJava
+++ b/installJava
@@ -1,42 +1,82 @@
 #!/bin/bash
 
+set -e
 export THIS_DIR="$PWD"
 
+# -----------------------------
+# Ask Minecraft version
+# -----------------------------
+echo ""
+echo "Enter Minecraft version (example: 1.14.2, 1.16.5, 1.18.2, 1.20.4):"
+read -r MC_VERSION
+
+# -----------------------------
+# Decide Java version
+# -----------------------------
+JAVA_PKG=""
+
+case "$MC_VERSION" in
+  1.1[0-6]*)
+    JAVA_PKG="temurin-8-jdk"
+    ;;
+  1.17*)
+    JAVA_PKG="temurin-16-jdk"
+    ;;
+  1.18*|1.19*|1.20.[0-4])
+    JAVA_PKG="temurin-17-jdk"
+    ;;
+  *)
+    JAVA_PKG="temurin-21-jdk"
+    ;;
+esac
+
+echo "> Minecraft $MC_VERSION detected"
+echo "> Installing Java: $JAVA_PKG"
+
+# -----------------------------
+# Dependencies (UNCHANGED)
+# -----------------------------
+sudo apt update -y
+sudo apt install -y screen neofetch curl wget apt-transport-https ca-certificates gnupg
+
+# -----------------------------
+# Adoptium repo
+# -----------------------------
+if ! grep -q adoptium /etc/apt/sources.list.d/adoptium.list 2>/dev/null; then
+  wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public \
+    | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/adoptium.gpg
+
+  echo "deb https://packages.adoptium.net/artifactory/deb $(lsb_release -cs) main" \
+    | sudo tee /etc/apt/sources.list.d/adoptium.list
+fi
+
+sudo apt update -y
+sudo apt install -y "$JAVA_PKG"
+
+echo "> Java installed:"
+java -version
+
+# -----------------------------
+# Server directory
+# -----------------------------
+mkdir -p server
+
+# -----------------------------
+# Server installer menu (UNCHANGED)
+# -----------------------------
 install_server () {
   choice="$1"
-
   cd JavaInstallScripts || exit 1
   chmod +x *
 
   case "$choice" in
-    ""|1)
-      echo "> Installing Vanilla..."
-      ./VanillaInstall
-      ;;
-    2)
-      echo "> Installing Paper..."
-      ./PaperInstall
-      ;;
-    3)
-      echo "> Installing Forge..."
-      ./ForgeInstall
-      ;;
-    4)
-      echo "> Installing Sponge..."
-      ./SpongeInstall
-      ;;
-    5)
-      echo "> Installing Fabric..."
-      ./FabricInstall
-      ;;
-    6)
-      echo "> Installing Spigot..."
-      ./SpigotInstall
-      ;;
-    7)
-      echo "> Installing Bungeecord..."
-      ./BungeecordInstall
-      ;;
+    ""|1) ./VanillaInstall ;;
+    2) ./PaperInstall ;;
+    3) ./ForgeInstall ;;
+    4) ./SpongeInstall ;;
+    5) ./FabricInstall ;;
+    6) ./SpigotInstall ;;
+    7) ./BungeecordInstall ;;
     *)
       echo "> Invalid response"
       cd "$THIS_DIR"
@@ -45,22 +85,6 @@ install_server () {
   esac
 }
 
-# -----------------------------
-# Dependencies
-# -----------------------------
-sudo apt update -y
-sudo apt install -y screen neofetch curl wget
-
-echo "> Dependencies installed"
-
-# -----------------------------
-# Server directory
-# -----------------------------
-mkdir -p server
-
-# -----------------------------
-# Menu
-# -----------------------------
 echo ""
 echo "-- Pick Server Type --"
 echo "[1] Vanilla"
@@ -73,11 +97,10 @@ echo "[7] Bungeecord"
 read -r choiceForServer
 
 install_server "$choiceForServer"
-
 cd "$THIS_DIR"
 
 # -----------------------------
-# Playit.gg install
+# Playit.gg (UNCHANGED)
 # -----------------------------
 echo "> Installing Playit.gg..."
 curl -SsL https://playit-cloud.github.io/ppa/key.gpg | sudo apt-key add -
@@ -89,7 +112,7 @@ sudo apt install -y playit
 echo "> Playit.gg installed"
 
 # -----------------------------
-# Start prompt
+# Start prompt (UNCHANGED)
 # -----------------------------
 echo ""
 echo "Start server now?"

--- a/installJava
+++ b/installJava
@@ -1,153 +1,104 @@
 #!/bin/bash
 
-export THIS_DIR=$PWD
+export THIS_DIR="$PWD"
 
 install_server () {
-  choice=$1
-  if [[ -z $choice ]]
-  then	
-    echo -e "\n> Installing Vanilla..."
-    cd JavaInstallScripts
-    chmod +x *
-    
-    ./VanillaInstall
-    errorno=${?}
-    if [ $errorno -eq 1 ]
-    then
-      cd $THIS_DIR
-      install_server $choice
-    fi
+  choice="$1"
 
+  cd JavaInstallScripts || exit 1
+  chmod +x *
 
-  # Vanilla
-  elif [[ $choice == 1 ]]
-  then
-    echo -e "\n> Installing Vanilla..."
-    cd JavaInstallScripts
-    chmod +x *
-
-    ./VanillaInstall
-    errorno=${?}
-    if [ $errorno -eq 1 ]
-    then
-	    cd $THIS_DIR
-      install_server $choice
-    fi
-
-  # Paper
-  elif [[ $choice == 2 ]]
-  then
-    echo "> Installing Paper..."
-    cd JavaInstallScripts
-    chmod +x *
-    ./PaperInstall
-
-  # Forge
-  elif [[ $choice == 3 ]]
-  then
-    echo "> Installing Forge..."
-    cd JavaInstallScripts
-    chmod +x *
-    ./ForgeInstall
-
-  # Sponge
-  elif [[ $choice == 4 ]]
-  then
-    echo "> Installing Sponge..."
-    cd JavaInstallScripts
-    chmod +x *
-    ./SpongeInstall
-
-  # Fabric
-  elif [[ $choice == 5 ]]
-  then
-    echo "> Installing Fabric..."
-    cd JavaInstallScripts
-    chmod +x *
-    ./FabricInstall
-
-
-  elif [[ $choice == 6 ]];then
-    echo "> Installing Spigot..."
-    cd JavaInstallScripts
-    chmod +x *
-    ./SpigotInstall
-
-
-  elif [[ $choice == 7 ]];then
-    echo "> Installing Bungeecord..."
-    cd JavaInstallScripts
-    chmod +x *
-    ./BungeecordInstall
-
-  
- # Invaild Input
-  else
-    echo "Invaild Responds! Please try again"
-    ./installJava
-  fi
+  case "$choice" in
+    ""|1)
+      echo "> Installing Vanilla..."
+      ./VanillaInstall
+      ;;
+    2)
+      echo "> Installing Paper..."
+      ./PaperInstall
+      ;;
+    3)
+      echo "> Installing Forge..."
+      ./ForgeInstall
+      ;;
+    4)
+      echo "> Installing Sponge..."
+      ./SpongeInstall
+      ;;
+    5)
+      echo "> Installing Fabric..."
+      ./FabricInstall
+      ;;
+    6)
+      echo "> Installing Spigot..."
+      ./SpigotInstall
+      ;;
+    7)
+      echo "> Installing Bungeecord..."
+      ./BungeecordInstall
+      ;;
+    *)
+      echo "> Invalid response"
+      cd "$THIS_DIR"
+      ./installJava
+      ;;
+  esac
 }
 
-#Installing all the dependencise
-sudo apt install -y -qq screen neofetch 
+# -----------------------------
+# Dependencies
+# -----------------------------
+sudo apt update -y
+sudo apt install -y screen neofetch curl wget
 
-echo "export PATH=$PATH:/some/new/path" > ~/.profile
-echo "> Dependencies Installtion Completed!"
+echo "> Dependencies installed"
 
-#Downloading ngrok && Downloading Minecraft Server
-mkdir server 
+# -----------------------------
+# Server directory
+# -----------------------------
+mkdir -p server
 
+# -----------------------------
+# Menu
+# -----------------------------
 echo ""
-echo "-- Pick the following Server type: --"
-echo "Type [1] Create Vanilla Server"
-echo "Type [2] Create Paper Server"
-echo "Type [3] Create Forge Server"
-echo "Type [4] Create Sponge Server"
-echo "Type [5] Create Fabric Server"
-echo "Type [6] Create Spigot Server(COMPILE)"
-echo "Type [7] Create Bungeecord Server(latest)"
-choiceForServer=1
-read choiceForServer
+echo "-- Pick Server Type --"
+echo "[1] Vanilla"
+echo "[2] Paper"
+echo "[3] Forge"
+echo "[4] Sponge"
+echo "[5] Fabric"
+echo "[6] Spigot"
+echo "[7] Bungeecord"
+read -r choiceForServer
 
-install_server $choiceForServer
+install_server "$choiceForServer"
 
-# Backup install playit.gg in case if first one doesn't download
+cd "$THIS_DIR"
+
+# -----------------------------
+# Playit.gg install
+# -----------------------------
 echo "> Installing Playit.gg..."
-cd ..
-#wget "https://playit.gg/downloads/playit-linux_64-0.4.2-rc1" -O playit 
-#wget -q "https://playit.gg/downloads/playit-linux_64-0.4.6" -O playit
-#wget -q "https://new.playit.gg/downloads/playit-0.7.0-beta" -O playit
-#wget -q "https://playit.gg/downloads/playit-0.7.5-beta" -O playit
-#wget -q "https://playit.gg/downloads/playit-0.8.1-beta" -O playit
-#chmod +x playit
-
-# NOte this is directly downloaded from the playit repository, anything can happen.
 curl -SsL https://playit-cloud.github.io/ppa/key.gpg | sudo apt-key add -
-sudo curl -SsL -o /etc/apt/sources.list.d/playit-cloud.list https://playit-cloud.github.io/ppa/playit-cloud.list
+sudo curl -SsL -o /etc/apt/sources.list.d/playit-cloud.list \
+  https://playit-cloud.github.io/ppa/playit-cloud.list
 sudo apt update
-sudo apt install playit
+sudo apt install -y playit
 
-echo "> Playit.gg Installation Completed!"
+echo "> Playit.gg installed"
+
+# -----------------------------
+# Start prompt
+# -----------------------------
 echo ""
-echo "-- Do you want to start the server now? --"
-echo "Type [1] for Yes"
-echo "Type [2] for No"
+echo "Start server now?"
+echo "[1] Yes"
+echo "[2] No"
+read -r StartServer
 
-StartServer=2
-read StartServer
-
-if [[ -z $StartServer ]]; then
-echo "> By Default, you selected 'No'."
-echo "> You can start the server by do ./startserver"
-
-elif [[ $StartServer == 1 ]]; then
-./startserver
-
-elif [[ $StartServer == 2 ]]; then
-echo "You picked 'No'."
-echo "> You can start the server by do ./startserver"
-
+if [[ "$StartServer" == "1" ]]; then
+  ./startserver
 else
-echo "> By Default, you selected 'No'."
-echo "> You can start the server by do ./startserver"
+  echo "You can start later using: ./startserver"
 fi

--- a/installJava
+++ b/installJava
@@ -8,7 +8,7 @@ export THIS_DIR="$PWD"
 # -----------------------------
 echo ""
 echo "Enter Minecraft version (example: 1.14.2, 1.16.5, 1.18.2, 1.20.4):"
-read -r MC_VERSION
+read -rp "> " MC_VERSION
 
 # -----------------------------
 # Decide Java version
@@ -94,7 +94,7 @@ echo "[4] Sponge"
 echo "[5] Fabric"
 echo "[6] Spigot"
 echo "[7] Bungeecord"
-read -r choiceForServer
+read -rp "> " choiceForServer
 
 install_server "$choiceForServer"
 cd "$THIS_DIR"
@@ -118,7 +118,7 @@ echo ""
 echo "Start server now?"
 echo "[1] Yes"
 echo "[2] No"
-read -r StartServer
+read -rp "> " StartServer
 
 if [[ "$StartServer" == "1" ]]; then
   ./startserver

--- a/startJavaServer
+++ b/startJavaServer
@@ -18,13 +18,8 @@ fi
 
 cd "$SERVER_DIR"
 
-# -----------------------------
-# RAM detection
-# -----------------------------
 mem_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
 mem_gb=$((mem_kb / 1024 / 1024))
-
-# Use 75% RAM (safe)
 RAM=$((mem_gb * 75 / 100))
 
 echo "Starting Minecraft with ${RAM}G RAM"

--- a/startJavaServer
+++ b/startJavaServer
@@ -1,13 +1,33 @@
 #!/bin/bash
-export MAIN_DIR=$PWD
-export JAVA=$MAIN_DIR/bin/java_bins/bin/java
-cd server
 
-mem=$(grep MemTotal /proc/meminfo | sed -e 's/MemTotal:[ ]*//' | sed -e 's/ kB//') # some new stuff 
+set -e
 
-mem=$(($mem/1024/1024))
+MAIN_DIR="$PWD"
+SERVER_DIR="$MAIN_DIR/server"
+JAVA="$(command -v java)"
 
-#uncomment this below line only if the server you are running is 1.17+ (if it is uncommented by default keep it as it is).
-$JAVA -Xmx${mem}G -Xms${mem}G -jar server.jar nogui
-# for 1.16 or lower uncomment this line
-#java -Xmx${mem}G -Xms${mem}G -jar server.jar nogui
+if [[ -z "$JAVA" ]]; then
+  echo "Java not found. Run ./install first."
+  exit 1
+fi
+
+if [[ ! -f "$SERVER_DIR/server.jar" ]]; then
+  echo "server.jar not found in server/"
+  exit 1
+fi
+
+cd "$SERVER_DIR"
+
+# -----------------------------
+# RAM detection
+# -----------------------------
+mem_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+mem_gb=$((mem_kb / 1024 / 1024))
+
+# Use 75% RAM (safe)
+RAM=$((mem_gb * 75 / 100))
+
+echo "Starting Minecraft with ${RAM}G RAM"
+echo "Java path: $JAVA"
+
+exec "$JAVA" -Xms${RAM}G -Xmx${RAM}G -jar server.jar nogui

--- a/startserver
+++ b/startserver
@@ -1,47 +1,52 @@
 #!/bin/bash
 export MAIN_DIR=$PWD
 echo "> Starting the server up. Please wait..."                                                                                 
-echo "> Installing Dependencise..."
+echo "> Installing Dependencies..."
 
-sudo apt install -y -qq screen wget  
+# Install required dependencies including JDK 21
+sudo apt update
+sudo apt install -y -qq screen wget openjdk-21-jdk
 
-echo "> Dependencise Installed!"
+echo "> Dependencies Installed!"
+
+# Set Java 21 as the default version
+echo "> Configuring Java version to JDK 21..."
+sudo update-alternatives --set java $(update-alternatives --list java | grep "java-21")
+
+# Verify the Java version
+java -version
 
 echo "> Checking Server Type..."
 if [ -f $MAIN_DIR/server/bedrock_server ]; then
-
-echo "> Bedrock Server Detected! Starting Server up..."
-
+    echo "> Bedrock Server Detected! Starting Server up..."
 elif [ ! -f $MAIN_DIR/server/eula.txt ]; then
-
-cd $MAIN_DIR/server
-echo "> EULA doesn't exist! Creating one!"
-echo "eula=true" > eula.txt
-echo "> EULA Completed! Restarting Server"
-cd $MAIN_DIR
-screen -S server -d -m ./startJavaServer
-clear
-echo "> Your server just doing a second restart to fix the EULA file."
-killall screen
-./startserver
-exit
+    cd $MAIN_DIR/server
+    echo "> EULA doesn't exist! Creating one!"
+    echo "eula=true" > eula.txt
+    echo "> EULA Completed! Restarting Server"
+    cd $MAIN_DIR
+    screen -S server -d -m ./startJavaServer
+    clear
+    echo "> Your server is performing a second restart to fix the EULA file."
+    killall screen
+    ./startserver
+    exit
 elif [ -f $MAIN_DIR/server/eula.txt ]; then
-echo "> EULA Detected! Starting Server up..."
-
+    echo "> EULA Detected! Starting Server up..."
 else
-echo "> Your server isn't setup properly. Force uninstall..."
-cd $MAIN_DIR
-./uninstall
-echo "> Comfirmed Uninstallation! Restarting Installation..."
-./install
+    echo "> Your server isn't set up properly. Force uninstall..."
+    cd $MAIN_DIR
+    ./uninstall
+    echo "> Confirmed Uninstallation! Restarting Installation..."
+    ./install
 fi
 
-# apparently ppl keep spamming startserver and end up having multiple screens of the same app
+# Prevent multiple instances of the same app from running
 killall screen
 
 screen -S server -d -m ./startJavaServer # Starting Java Server
 screen -S server -d -m ./startBedrockServer # Starting Bedrock Server
-screen -S afk -d -m ./startAfk #Starting AFK app aka bpytop.
+screen -S afk -d -m ./startAfk # Starting AFK app aka bpytop.
 screen -S playit -d -m ./startPlayIt # Starting Playit
 
 cd $MAIN_DIR/server
@@ -57,5 +62,5 @@ echo "Type [screen -r playit] to view your Server IP"
 echo ""
 echo "> To stop your server, type './stopserver' to stop"
 
-echo -e '\nchecking if server has launched properly'
+echo -e '\nChecking if the server has launched properly'
 ./.checkserver 2> crash.log


### PR DESCRIPTION
### Java Install Logic Update

- Java installation path has been changed to use ./installJava
- Java version selection is now based on the selected Minecraft version
- Ensures correct Java compatibility for older and newer Minecraft versions
- Refactored Java Launch Script

### Paper API Update

- Updated PaperMC download logic from the old API to PaperMC API v2
- Uses the new /v2/projects/paper endpoints
- Improves reliability and future compatibility of Paper installs

